### PR TITLE
Added Nexus Update Key

### DIFF
--- a/BetterHitboxStardew/manifest.json
+++ b/BetterHitboxStardew/manifest.json
@@ -6,5 +6,5 @@
   "UniqueID": "kodfod.hitbox",
   "EntryDll": "BetterHitboxStardew.dll",
   "MinimumApiVersion": "2.10.0",
-  "UpdateKeys": ["GitHub:kodfod/BetterHitboxStardew"]
+  "UpdateKeys": ["GitHub:kodfod/BetterHitboxStardew", "Nexus:4973"]
 }


### PR DESCRIPTION
SMAPI will now check GitHub first, then Nexus, and choose the newest version. If both GitHub and Nexus have the same latest version, it will use the first key in the list.